### PR TITLE
Add timeout to upload very long files

### DIFF
--- a/lib/b2_client/backend/httpoison.ex
+++ b/lib/b2_client/backend/httpoison.ex
@@ -149,7 +149,11 @@ defmodule B2Client.Backend.HTTPoison do
       {"X-Bz-Content-Sha1", sha1hash(iodata)}
     ]
 
-    case post(auth.upload_url, iodata, headers, []) do
+    options = [
+      recv_timeout: :infinity
+    ]
+
+    case post(auth.upload_url, iodata, headers, options) do
       {:ok, %{status_code: 200, body: original_body}} ->
         body = Jason.decode!(original_body)
         {:ok, to_file(body)}


### PR DESCRIPTION
Just I add an option to wait for HTTPoison response when files are very long. Before that, files with 2Mb or more returned this error:

`** (MatchError) no match of right hand side value: {:error, %HTTPoison.Error{id: nil, reason: :timeout}}`